### PR TITLE
accelerate extract_patches tens of times!

### DIFF
--- a/lib/NonparametricPatchAutoencoderFactory.lua
+++ b/lib/NonparametricPatchAutoencoderFactory.lua
@@ -1,5 +1,4 @@
 require 'nn'
-local floor = math.floor
 local NonparametricPatchAutoencoderFactory = torch.class('NonparametricPatchAutoencoderFactory')
 
 function NonparametricPatchAutoencoderFactory.buildAutoencoder(target_img, patch_size, stride, shuffle, normalize, interpolate)
@@ -97,20 +96,11 @@ end
 function NonparametricPatchAutoencoderFactory._extract_patches(img, patch_size, stride, shuffle)
     local nDim = 3
     assert(img:nDimension() == nDim, 'image must be of dimension 3.')
-    local C, H, W = img:size(nDim-2), img:size(nDim-1), img:size(nDim)
-    local nH = floor( (H - patch_size)/stride + 1)
-    local nW = floor( (W - patch_size)/stride + 1)
-
-    -- extract patches
-    local patches = torch.Tensor(nH*nW, C, patch_size, patch_size):typeAs(img)
-    for i=1,nH*nW do
-        local h = floor((i-1)/nW)  -- zero-index
-        local w = floor((i-1)%nW)  -- zero-index
-        patches[i] = img[{{},
-        {1 + h*stride, 1 + h*stride + patch_size-1},
-        {1 + w*stride, 1 + w*stride + patch_size-1}
-        }]
-    end
+    local kH, kW = patch_size, patch_size
+    local dH, dW = stride, stride
+    local patches = img:unfold(2, kh, kW):unfold(3, kW, dW)
+    local n1, n2, n3, n4, n5 = patches:size(1), patches:size(2), patches:size(3), patches:size(4), patches:size(5)
+    patches = patches:permute(2,3,1,4,5):contiguous():view(n2*n3, n1, n4, n5)
 
     if shuffle then
         local shuf = torch.randperm(patches:size(1)):long()

--- a/lib/NonparametricPatchAutoencoderFactory.lua
+++ b/lib/NonparametricPatchAutoencoderFactory.lua
@@ -97,20 +97,11 @@ end
 function NonparametricPatchAutoencoderFactory._extract_patches(img, patch_size, stride, shuffle)
     local nDim = 3
     assert(img:nDimension() == nDim, 'image must be of dimension 3.')
-    local C, H, W = img:size(nDim-2), img:size(nDim-1), img:size(nDim)
-    local nH = math.floor( (H - patch_size)/stride + 1)
-    local nW = math.floor( (W - patch_size)/stride + 1)
-
-    -- extract patches
-    local patches = torch.Tensor(nH*nW, C, patch_size, patch_size):typeAs(img)
-    for i=1,nH*nW do
-        local h = math.floor((i-1)/nW)  -- zero-index
-        local w = math.floor((i-1)%nW)  -- zero-index
-        patches[i] = img[{{},
-        {1 + h*stride, 1 + h*stride + patch_size-1},
-        {1 + w*stride, 1 + w*stride + patch_size-1}
-        }]
-    end
+    local kH, kW = patch_size, patch_size
+    local dH, dW = stride, stride
+    local patches = img:unfold(2, kh, kW):unfold(3, kW, dW)
+    local n1, n2, n3, n4, n5 = patches:size(1), patches:size(2), patches:size(3), patches:size(4), patches:size(5)
+    patches = patches:permute(2,3,1,4,5):contiguous():view(n2*n3, n1, n4, n5)
 
     if shuffle then
         local shuf = torch.randperm(patches:size(1)):long()

--- a/lib/NonparametricPatchAutoencoderFactory.lua
+++ b/lib/NonparametricPatchAutoencoderFactory.lua
@@ -1,5 +1,5 @@
 require 'nn'
-
+local floor = math.floor
 local NonparametricPatchAutoencoderFactory = torch.class('NonparametricPatchAutoencoderFactory')
 
 function NonparametricPatchAutoencoderFactory.buildAutoencoder(target_img, patch_size, stride, shuffle, normalize, interpolate)
@@ -97,11 +97,20 @@ end
 function NonparametricPatchAutoencoderFactory._extract_patches(img, patch_size, stride, shuffle)
     local nDim = 3
     assert(img:nDimension() == nDim, 'image must be of dimension 3.')
-    local kH, kW = patch_size, patch_size
-    local dH, dW = stride, stride
-    local patches = img:unfold(2, kh, kW):unfold(3, kW, dW)
-    local n1, n2, n3, n4, n5 = patches:size(1), patches:size(2), patches:size(3), patches:size(4), patches:size(5)
-    patches = patches:permute(2,3,1,4,5):contiguous():view(n2*n3, n1, n4, n5)
+    local C, H, W = img:size(nDim-2), img:size(nDim-1), img:size(nDim)
+    local nH = floor( (H - patch_size)/stride + 1)
+    local nW = floor( (W - patch_size)/stride + 1)
+
+    -- extract patches
+    local patches = torch.Tensor(nH*nW, C, patch_size, patch_size):typeAs(img)
+    for i=1,nH*nW do
+        local h = floor((i-1)/nW)  -- zero-index
+        local w = floor((i-1)%nW)  -- zero-index
+        patches[i] = img[{{},
+        {1 + h*stride, 1 + h*stride + patch_size-1},
+        {1 + w*stride, 1 + w*stride + patch_size-1}
+        }]
+    end
 
     if shuffle then
         local shuf = torch.randperm(patches:size(1)):long()

--- a/lib/StylePatchLossModule.lua
+++ b/lib/StylePatchLossModule.lua
@@ -20,10 +20,10 @@ function module._extract_patches(img, patch_size, stride)
     local nDim = 3
     assert(img:nDimension() == nDim, 'image must be of dimension 3.')
     
-    kH, kW = patch_size, patch_size
-    dH, dW = stride, stride
+    local kH, kW = patch_size, patch_size
+    local dH, dW = stride, stride
     local patches = img:unfold(2, kh, kW):unfold(3, kW, dW)
-    n1, n2, n3, n4, n5 = patches:size(1), patches:size(2), patches:size(3), patches:size(4), patches:size(5)
+    local n1, n2, n3, n4, n5 = patches:size(1), patches:size(2), patches:size(3), patches:size(4), patches:size(5)
     patches = patches:permute(2,3,1,4,5):contiguous():view(n2*n3, n1, n4, n5)
 
     return patches

--- a/lib/StylePatchLossModule.lua
+++ b/lib/StylePatchLossModule.lua
@@ -19,6 +19,21 @@ end
 function module._extract_patches(img, patch_size, stride)
     local nDim = 3
     assert(img:nDimension() == nDim, 'image must be of dimension 3.')
+    
+    kH, kW = patch_size, patch_size
+    dH, dW = stride, stride
+    local patches = img:unfold(2, kh, kW):unfold(3, kW, dW)
+    n1, n2, n3, n4, n5 = patches:size(1), patches:size(2), patches:size(3), patches:size(4), patches:size(5)
+    patches = patches:permute(2,3,1,4,5):contiguous():view(n2*n3, n1, n4, n5)
+
+    return patches
+end
+
+-- This approach of extracting patches is much slower.
+--[[
+function module._extract_patches(img, patch_size, stride)
+    local nDim = 3
+    assert(img:nDimension() == nDim, 'image must be of dimension 3.')
     local C, H, W = img:size(nDim-2), img:size(nDim-1), img:size(nDim)
     local nH = math.floor( (H - patch_size)/stride + 1)
     local nW = math.floor( (W - patch_size)/stride + 1)
@@ -36,6 +51,7 @@ function module._extract_patches(img, patch_size, stride)
 
     return patches
 end
+]]
 
 function module:setTarget(target_features, patch_size, patch_stride)
     assert(target_features:nDimension() == 3, 'Target must be 3D')


### PR DESCRIPTION
Here is perf comparison snippet
```lua
require 'torch'
require 'cunn'
require 'cutorch'
cutorch.setDevice(1)

img = torch.randn(256,32,32):cuda()
nDim = 3
patch_size = 3
stride = 2

local timer1 = torch.Timer()
for i = 1, ntimes do
    local C, H, W = img:size(nDim-2), img:size(nDim-1), img:size(nDim)
    local nH = math.floor( (H - patch_size)/stride + 1)
    local nW = math.floor( (W - patch_size)/stride + 1)

    -- extract patches
    local patches = torch.Tensor(nH*nW, C, patch_size, patch_size):typeAs(img)
    for i=1,nH*nW do
        local h = math.floor((i-1)/nW)  -- zero-index
        local w = math.floor((i-1)%nW)  -- zero-index
        patches[i] = img[{{},
        {1 + h*stride, 1 + h*stride + patch_size-1},
        {1 + w*stride, 1 + w*stride + patch_size-1}
        }]
    end
end
print('Method 1: '..timer1:time().real..' seconds')

timer2 = torch.Timer()
for i = 1, ntimes do
    kh, kW = patch_size,patch_size
    dh, dW = stride,stride
    input_windows = img:unfold(2, kh, kW):unfold(3, kW, dW)

    i_1, i_2, i_3, i_4, i_5 = input_windows:size(1), input_windows:size(2), input_windows:size(3), input_windows:size(4), input_windows:size(5)
    input_windows = input_windows:permute(2,3,1,4,5):contiguous():view(i_2*i_3, i_1, i_4, i_5)
end
print('Method 2: '..timer2:time().real..' seconds')
```
```bash
Method 1: 23.98521399498 seconds
Method 2: 1.0258769989014 seconds
```